### PR TITLE
Adjusted XPATH to be more specific

### DIFF
--- a/islandora_transforms/slurp_all_MODS_to_solr.xslt
+++ b/islandora_transforms/slurp_all_MODS_to_solr.xslt
@@ -30,11 +30,11 @@
     </xsl:apply-templates>
   </xsl:template>
 
-  <xsl:template match="mods:relatedItem[@type='host'][mods:location[not(@*)]/mods:physicalLocation[not(@*)]]" mode="slurping_MODS">
+  <xsl:template match="mods:relatedItem[@type='host']/mods:location[not(@*)]/mods:physicalLocation[not(@*)]" mode="slurping_MODS">
     <!-- client request to not index this path -->
   </xsl:template>
 
- <xsl:template match="mods:location[not(@*)][mods:physicalLocation[not(@*)]]" mode="slurping_MODS">
+  <xsl:template match="mods:location[not(@*)]/mods:physicalLocation[not(@*)]" mode="slurping_MODS">
     <!-- client request to not index this path -->
   </xsl:template>
 


### PR DESCRIPTION
Regarding Pull #5 and Pull #6, it was later discovered that the client requires mods_relatedItem_host_titleInfo_title & mods_relatedItem_host_identifier_local to be indexed. The XPATH has been altered to be more specific and only ignore the fields that were requested.